### PR TITLE
Fix/nullability issues

### DIFF
--- a/config.gradle
+++ b/config.gradle
@@ -7,7 +7,7 @@ ext {
     ]
     releaseConfig = [
             "group"      : "com.infinum.jsonapix",
-            "version"    : "1.0.0-alpha",
-            "versionCode": 0 * 10000 + 0 * 100 + 2
+            "version"    : "1.0.0-alpha02",
+            "versionCode": 0 * 10000 + 0 * 100 + 3
     ]
 }

--- a/processor/src/main/java/com/infinum/jsonapix/processor/specs/AttributesSpecBuilder.kt
+++ b/processor/src/main/java/com/infinum/jsonapix/processor/specs/AttributesSpecBuilder.kt
@@ -25,6 +25,11 @@ internal object AttributesSpecBuilder {
         val parameterSpecs = attributes.map {
             ParameterSpec.builder(it.name, it.type)
                 .addAnnotation(Specs.getSerialNameSpec(it.name))
+                .apply {
+                    if (it.type.isNullable) {
+                        defaultValue("%L", null)
+                    }
+                }
                 .build()
         }
 

--- a/processor/src/main/java/com/infinum/jsonapix/processor/specs/ResourceObjectSpecBuilder.kt
+++ b/processor/src/main/java/com/infinum/jsonapix/processor/specs/ResourceObjectSpecBuilder.kt
@@ -198,7 +198,6 @@ internal object ResourceObjectSpecBuilder {
             }
         }
 
-        val relationshipsLiteral = "relationships"
         oneRelationships.forEach {
             codeBlockBuilder.addStatement("%N = relationships?.let { safeRelationships ->", it.key)
             codeBlockBuilder.indent().addStatement("included?.first {")

--- a/processor/src/main/java/com/infinum/jsonapix/processor/specs/ResourceObjectSpecBuilder.kt
+++ b/processor/src/main/java/com/infinum/jsonapix/processor/specs/ResourceObjectSpecBuilder.kt
@@ -202,10 +202,17 @@ internal object ResourceObjectSpecBuilder {
         oneRelationships.forEach {
             codeBlockBuilder.addStatement("%N = relationships?.let { safeRelationships ->", it.key)
             codeBlockBuilder.indent().addStatement("included?.first {")
-            codeBlockBuilder.indent().addStatement(
-                "safeRelationships.%N.data == ResourceIdentifier(it.type, it.id)",
-                it.key
-            )
+            if (it.value.isNullable) {
+                codeBlockBuilder.indent().addStatement(
+                    "safeRelationships.%N?.data == ResourceIdentifier(it.type, it.id)",
+                    it.key
+                )
+            } else {
+                codeBlockBuilder.indent().addStatement(
+                    "safeRelationships.%N.data == ResourceIdentifier(it.type, it.id)",
+                    it.key
+                )
+            }
             codeBlockBuilder.unindent()
             codeBlockBuilder.addStatement("}?.${JsonApiConstants.Members.ORIGINAL}(included) as %T", it.value)
             if (it.value.isNullable) {
@@ -214,7 +221,7 @@ internal object ResourceObjectSpecBuilder {
                 codeBlockBuilder.unindent().addStatement(
                     "} ?: throw %T(%S),",
                     JsonApiXMissingArgumentException::class,
-                    relationshipsLiteral
+                    it.key
                 )
             }
         }
@@ -222,10 +229,17 @@ internal object ResourceObjectSpecBuilder {
         manyRelationships.forEach {
             codeBlockBuilder.addStatement("%N = relationships?.let { safeRelationships ->", it.key)
             codeBlockBuilder.indent().addStatement("included?.filter {")
-            codeBlockBuilder.indent().addStatement(
-                "safeRelationships.%N.data.contains(ResourceIdentifier(it.type, it.id))",
-                it.key
-            )
+            if (it.value.isNullable) {
+                codeBlockBuilder.indent().addStatement(
+                    "safeRelationships.%N?.data?.contains(ResourceIdentifier(it.type, it.id)) == true",
+                    it.key
+                )
+            } else {
+                codeBlockBuilder.indent().addStatement(
+                    "safeRelationships.%N.data.contains(ResourceIdentifier(it.type, it.id))",
+                    it.key
+                )
+            }
             codeBlockBuilder.unindent().addStatement(
                 "}?.map { it.${JsonApiConstants.Members.ORIGINAL}(included) } as %T",
                 it.value
@@ -236,7 +250,7 @@ internal object ResourceObjectSpecBuilder {
                 codeBlockBuilder.unindent().addStatement(
                     "} ?: throw %T(%S),",
                     JsonApiXMissingArgumentException::class,
-                    relationshipsLiteral
+                    it.key
                 )
             }
         }

--- a/sample/src/main/assets/responses/person_list_no_relationships.json
+++ b/sample/src/main/assets/responses/person_list_no_relationships.json
@@ -15,7 +15,6 @@
       "id": "1",
       "attributes": {
         "age": 28,
-        "name": "Jason",
         "surname": "Apix"
       },
       "relationships": {

--- a/sample/src/main/assets/responses/person_list_no_relationships.json
+++ b/sample/src/main/assets/responses/person_list_no_relationships.json
@@ -17,6 +17,14 @@
         "age": 28,
         "name": "Jason",
         "surname": "Apix"
+      },
+      "relationships": {
+        "myFavoriteDog": {
+          "data": {
+            "id": "1",
+            "type": "dog"
+          }
+        }
       }
     },
     {
@@ -29,6 +37,16 @@
         "age": 28,
         "name": "Jasminka",
         "surname": "Apix"
+      }
+    }
+  ],
+  "included": [
+    {
+      "type":"dog",
+      "id":"1",
+      "attributes":{
+        "age":1,
+        "name":"Bella"
       }
     }
   ]


### PR DESCRIPTION
Long story short, all nullable values must default to null in our wrapper classes. Otherwise, kotlinx serialization will try to produce them from string anyway. If they are missing, kotlinx will produce a crash. 
I did some other nullability changes, mostly to our relationships wrappers. They were not accounting for the nullability of relationships. 
Now `OneRelationshipMember` and `ManyRelationshipMember` can be null. Some methods changed to adjust to this change.
Also, I've updated the `person_list_no_relationships.json` to test these changes, and everything works fine