### PR TITLE
fix: skip adding @SerialName when it's already there

### DIFF
--- a/processor/src/main/java/com/infinum/jsonapix/processor/specs/AttributesSpecBuilder.kt
+++ b/processor/src/main/java/com/infinum/jsonapix/processor/specs/AttributesSpecBuilder.kt
@@ -3,18 +3,23 @@ package com.infinum.jsonapix.processor.specs
 import com.infinum.jsonapix.core.common.JsonApiConstants
 import com.infinum.jsonapix.core.common.JsonApiConstants.Prefix.withName
 import com.infinum.jsonapix.core.resources.Attributes
+import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.asClassName
+import com.squareup.kotlinpoet.asTypeName
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 internal object AttributesSpecBuilder {
 
     private val serializableClassName = Serializable::class.asClassName()
+    private val serialNameTypeName = SerialName::class.asTypeName()
 
     fun build(
         className: ClassName,
@@ -24,8 +29,10 @@ internal object AttributesSpecBuilder {
         val generatedName = JsonApiConstants.Prefix.ATTRIBUTES.withName(className.simpleName)
         val parameterSpecs = attributes.map {
             ParameterSpec.builder(it.name, it.type)
-                .addAnnotation(Specs.getSerialNameSpec(it.name))
                 .apply {
+                    if (it.annotations.missingTypeName(serialNameTypeName)) {
+                        addAnnotation(Specs.getSerialNameSpec(it.name))
+                    }
                     if (it.type.isNullable) {
                         defaultValue("%L", null)
                     }
@@ -52,6 +59,10 @@ internal object AttributesSpecBuilder {
             )
             .addProperties(attributes)
             .build()
+    }
+
+    private fun List<AnnotationSpec>.missingTypeName(typeName: TypeName): Boolean {
+        return indexOfFirst { it.typeName == typeName } < 0
     }
 
     private fun fromOriginalObjectSpec(


### PR DESCRIPTION
Hello and thank you for the lib! This is to solve the following issue:

1. As soon as we start using `@SerialName`, like downbelow for example:
```kotlin
@JsonApiX(type = "address")
@Serializable
data class Address(
    @SerialName("street") val streetName: String,
    val number: Int,
    val country: String,
    val city: String
) : JsonApiModel()
```
2. Our code gen looks like this (please notice annotation doubling) :
```kotlin
@Serializable
@SerialName(value = "Attributes_address")
public data class Attributes_Address(
  @SerialName(value = "city")
  public val city: String,
  @SerialName(value = "country")
  public val country: String,
  @SerialName(value = "number")
  public val number: Int,
  @property:SerialName(value = "street")
  @SerialName(value = "streetName")
  public val streetName: String
) : Attributes {
  public companion object {
    public fun fromOriginalObject(originalObject: Address) = Attributes_Address(city =
        originalObject.city, country = originalObject.country, number = originalObject.number,
        streetName = originalObject.streetName)
  }
}
```

With the fix, the code generated will look like this:

```kotlin
@Serializable
@SerialName(value = "Attributes_address")
public data class Attributes_Address(
  @SerialName(value = "city")
  public val city: String,
  @SerialName(value = "country")
  public val country: String,
  @SerialName(value = "number")
  public val number: Int,
  @property:SerialName(value = "street")
  public val streetName: String
) : Attributes {
  public companion object {
    public fun fromOriginalObject(originalObject: Address) = Attributes_Address(city =
        originalObject.city, country = originalObject.country, number = originalObject.number,
        streetName = originalObject.streetName)
  }
}
```

I understand it's not perfect solution, but it works and I'm lazy :)