### PR TITLE
Implement set/getId on JsonApiModel to enable client id mods

### DIFF
--- a/core/src/main/java/com/infinum/jsonapix/core/JsonApiModel.kt
+++ b/core/src/main/java/com/infinum/jsonapix/core/JsonApiModel.kt
@@ -6,10 +6,15 @@ import com.infinum.jsonapix.core.resources.Meta
 
 @Suppress("UNCHECKED_CAST", "TooManyFunctions", "UnnecessaryAbstractClass")
 abstract class JsonApiModel {
+    private var id: String? = "0"
     private var rootLinks: Links? = null
     private var resourceLinks: Links? = null
     private var relationshipLinks: Map<String, Links?>? = null
     private var meta: Meta? = null
+
+    fun setId(id: String?) {
+        this.id = id
+    }
 
     fun setRootLinks(links: Links?) {
         rootLinks = links
@@ -26,6 +31,8 @@ abstract class JsonApiModel {
     fun setMeta(meta: Meta?) {
         this.meta = meta
     }
+
+    fun id(): String? = id
 
     fun rootLinks(): DefaultLinks? = rootLinks as? DefaultLinks
 

--- a/core/src/main/java/com/infinum/jsonapix/core/common/JsonApiConstants.kt
+++ b/core/src/main/java/com/infinum/jsonapix/core/common/JsonApiConstants.kt
@@ -89,7 +89,8 @@ object JsonApiConstants {
     object Imports {
         val JSON_X = arrayOf(
             "core.JsonApiX",
-            "core.resources.ResourceObject"
+            "core.resources.ResourceObject",
+            "core.JsonApiModel"
         )
 
         val KOTLINX = arrayOf(

--- a/processor/src/main/java/com/infinum/jsonapix/processor/specs/TypeAdapterListSpecBuilder.kt
+++ b/processor/src/main/java/com/infinum/jsonapix/processor/specs/TypeAdapterListSpecBuilder.kt
@@ -103,6 +103,7 @@ public object TypeAdapterListSpecBuilder {
             .addStatement("data.data?.let { resourceData ->")
             .addStatement("original.zip(resourceData) { model, resource ->")
             .addStatement("(model as? %T)?.let { safeModel ->", JsonApiModel::class)
+            .addStatement("safeModel.setId(resource.id)")
             .addStatement("safeModel.setRootLinks(data.links)")
             .addStatement("safeModel.setResourceLinks(resource.links)")
             .addStatement("safeModel.setMeta(data.meta)")

--- a/processor/src/main/java/com/infinum/jsonapix/processor/specs/TypeAdapterSpecBuilder.kt
+++ b/processor/src/main/java/com/infinum/jsonapix/processor/specs/TypeAdapterSpecBuilder.kt
@@ -90,6 +90,7 @@ public object TypeAdapterSpecBuilder {
             )
             .addStatement("val original = data.${JsonApiConstants.Members.ORIGINAL}")
             .addStatement("(original as? %T)?.let {", JsonApiModel::class)
+            .addStatement("it.setId(data.data?.id)")
             .addStatement("it.setRootLinks(data.links)")
             .addStatement("it.setResourceLinks(data.data?.links)")
             .addStatement("data.data?.relationshipsLinks()?.let { links -> it.setRelationshipsLinks(links) }")

--- a/processor/src/main/java/com/infinum/jsonapix/processor/specs/jsonxextensions/funspecbuilders/ResourceObjectFunSpecBuilder.kt
+++ b/processor/src/main/java/com/infinum/jsonapix/processor/specs/jsonxextensions/funspecbuilders/ResourceObjectFunSpecBuilder.kt
@@ -15,6 +15,8 @@ internal object ResourceObjectFunSpecBuilder {
         val returnStatement = StringBuilder("return %T(")
         val builderArgs = mutableListOf<Any>(resourceObjectClass)
 
+        returnStatement.append("id = (this as? JsonApiModel)?.let { it.id() } ?: \"0\", ")
+
         if (attributesClass != null) {
             returnStatement.append(
                 "attributes = %T.${JsonApiConstants.Members.FROM_ORIGINAL_OBJECT}(this)"


### PR DESCRIPTION
Per user request https://github.com/infinum/kotlin-jsonapix/issues/20

https://app.productive.io/1-infinum/tasks/3329531

Since we're using retromock on sample, the feature is tested in a real world scenario and works as expected.