### PR TITLE
Inherit from custom/default link classes when building main model class

### DIFF
--- a/processor/src/main/java/com/infinum/jsonapix/processor/ClassInfo.kt
+++ b/processor/src/main/java/com/infinum/jsonapix/processor/ClassInfo.kt
@@ -14,4 +14,5 @@ internal data class ClassInfo(
     val includedStatement: CodeBlock?,
     val includedListStatement: CodeBlock?,
     val metaInfo: MetaInfo?,
+    val linksInfo: LinksInfo?,
 )

--- a/processor/src/main/java/com/infinum/jsonapix/processor/JsonApiProcessor.kt
+++ b/processor/src/main/java/com/infinum/jsonapix/processor/JsonApiProcessor.kt
@@ -169,10 +169,12 @@ public class JsonApiProcessor : AbstractProcessor() {
         }
 
         val metaInfo = customMetas.firstOrNull { it.type == type }
+        val linksInfo = customLinks.firstOrNull { it.type == type }
 
         collector.add(
             type = type,
             metaInfo = metaInfo,
+            linksInfo = linksInfo,
             isNullable = isNullable,
             data = inputDataClass,
             wrapper = jsonWrapperClassName,
@@ -192,22 +194,23 @@ public class JsonApiProcessor : AbstractProcessor() {
 
         adapterFactoryCollector.add(inputDataClass)
 
+
         val resourceFileSpec =
             ResourceObjectSpecBuilder.build(
                 className = inputDataClass,
                 metaClassName = metaInfo?.resourceObjectClassName,
+                linksInfo = linksInfo,
                 type = type,
                 attributes = primitives,
                 oneRelationships = mapOf(*oneRelationships.map { it.name to it.type }.toTypedArray()),
                 manyRelationships = mapOf(*manyRelationships.map { it.name to it.type }.toTypedArray())
             )
 
-        val linksInfo = customLinks.firstOrNull { it.type == type }
 
         val wrapperFileSpec =
-            JsonApiXSpecBuilder.build(inputDataClass, isNullable, type, metaInfo)
+            JsonApiXSpecBuilder.build(inputDataClass, isNullable, type, metaInfo, linksInfo)
         val wrapperListFileSpec =
-            JsonApiXListSpecBuilder.build(inputDataClass, isNullable, type, metaInfo)
+            JsonApiXListSpecBuilder.build(inputDataClass, isNullable, type, metaInfo, linksInfo)
         val modelFileSpec = JsonApiModelSpecBuilder.build(inputDataClass, isNullable, metaInfo, linksInfo)
         val listItemFileSpec = JsonApiListItemSpecBuilder.build(inputDataClass, isNullable, metaInfo, linksInfo)
         val listFileSpec = JsonApiListSpecBuilder.build(inputDataClass, isNullable, metaInfo, linksInfo)
@@ -267,26 +270,16 @@ public class JsonApiProcessor : AbstractProcessor() {
             )
             customLinks.firstOrNull { linksInfo -> linksInfo.type == type }?.let { linksInfo ->
                 when (placementStrategy) {
-                    LinksPlacementStrategy.ROOT -> linksInfo.rootLinks = className.canonicalName
-                    LinksPlacementStrategy.DATA ->
-                        linksInfo.resourceObjectLinks =
-                            className.canonicalName
-
-                    LinksPlacementStrategy.RELATIONSHIPS ->
-                        linksInfo.relationshipsLinks =
-                            className.canonicalName
+                    LinksPlacementStrategy.ROOT -> linksInfo.rootLinks = className
+                    LinksPlacementStrategy.DATA -> linksInfo.resourceObjectLinks = className
+                    LinksPlacementStrategy.RELATIONSHIPS -> linksInfo.relationshipsLinks = className
                 }
             } ?: kotlin.run {
                 val linksInfo = LinksInfo(type)
                 when (placementStrategy) {
-                    LinksPlacementStrategy.ROOT -> linksInfo.rootLinks = className.canonicalName
-                    LinksPlacementStrategy.DATA ->
-                        linksInfo.resourceObjectLinks =
-                            className.canonicalName
-
-                    LinksPlacementStrategy.RELATIONSHIPS ->
-                        linksInfo.relationshipsLinks =
-                            className.canonicalName
+                    LinksPlacementStrategy.ROOT -> linksInfo.rootLinks = className
+                    LinksPlacementStrategy.DATA -> linksInfo.resourceObjectLinks = className
+                    LinksPlacementStrategy.RELATIONSHIPS -> linksInfo.relationshipsLinks = className
                 }
                 customLinks.add(linksInfo)
             }
@@ -306,25 +299,15 @@ public class JsonApiProcessor : AbstractProcessor() {
             customMetas.firstOrNull { metaInfo -> metaInfo.type == type }?.let { metaInfo ->
                 when (placementStrategy) {
                     MetaPlacementStrategy.ROOT -> metaInfo.rootClassName = className
-                    MetaPlacementStrategy.DATA ->
-                        metaInfo.resourceObjectClassName =
-                            className
-
-                    MetaPlacementStrategy.RELATIONSHIPS ->
-                        metaInfo.relationshipsClassNAme =
-                            className
+                    MetaPlacementStrategy.DATA -> metaInfo.resourceObjectClassName = className
+                    MetaPlacementStrategy.RELATIONSHIPS -> metaInfo.relationshipsClassNAme = className
                 }
             } ?: kotlin.run {
                 val metaInfo = MetaInfo(type)
                 when (placementStrategy) {
                     MetaPlacementStrategy.ROOT -> metaInfo.rootClassName = className
-                    MetaPlacementStrategy.DATA ->
-                        metaInfo.resourceObjectClassName =
-                            className
-
-                    MetaPlacementStrategy.RELATIONSHIPS ->
-                        metaInfo.relationshipsClassNAme =
-                            className
+                    MetaPlacementStrategy.DATA -> metaInfo.resourceObjectClassName = className
+                    MetaPlacementStrategy.RELATIONSHIPS -> metaInfo.relationshipsClassNAme = className
                 }
                 customMetas.add(metaInfo)
             }

--- a/processor/src/main/java/com/infinum/jsonapix/processor/LinksInfo.kt
+++ b/processor/src/main/java/com/infinum/jsonapix/processor/LinksInfo.kt
@@ -1,8 +1,10 @@
 package com.infinum.jsonapix.processor
 
+import com.squareup.kotlinpoet.ClassName
+
 public data class LinksInfo(
     val type: String,
-    var rootLinks: String? = null,
-    var resourceObjectLinks: String? = null,
-    var relationshipsLinks: String? = null
+    var rootLinks: ClassName? = null,
+    var resourceObjectLinks: ClassName? = null,
+    var relationshipsLinks: ClassName? = null
 )

--- a/processor/src/main/java/com/infinum/jsonapix/processor/specs/BaseTypeAdapterSpecBuilder.kt
+++ b/processor/src/main/java/com/infinum/jsonapix/processor/specs/BaseTypeAdapterSpecBuilder.kt
@@ -33,9 +33,9 @@ public abstract class BaseTypeAdapterSpecBuilder {
 
     public fun build(
         className: ClassName,
-        rootLinks: String?,
-        resourceObjectLinks: String?,
-        relationshipsLinks: String?,
+        rootLinks: ClassName?,
+        resourceObjectLinks: ClassName?,
+        relationshipsLinks: ClassName?,
         rootMeta: ClassName?,
         resourceObjectMeta: ClassName?,
         relationshipsMeta: ClassName?,
@@ -55,15 +55,15 @@ public abstract class BaseTypeAdapterSpecBuilder {
                     .addFunction(convertFromStringFunSpec(className, modelType, rootMeta, resourceObjectMeta, relationshipsMeta))
                     .apply {
                         if (rootLinks != null) {
-                            addFunction(linksFunSpec(JsonApiConstants.Members.ROOT_LINKS, rootLinks))
+                            addFunction(linksFunSpec(JsonApiConstants.Members.ROOT_LINKS, rootLinks.canonicalName))
                         }
                         if (resourceObjectLinks != null) {
                             addFunction(
-                                linksFunSpec(JsonApiConstants.Members.RESOURCE_OBJECT_LINKS, resourceObjectLinks)
+                                linksFunSpec(JsonApiConstants.Members.RESOURCE_OBJECT_LINKS, resourceObjectLinks.canonicalName)
                             )
                         }
                         if (relationshipsLinks != null) {
-                            addFunction(linksFunSpec(JsonApiConstants.Members.RELATIONSHIPS_LINKS, relationshipsLinks))
+                            addFunction(linksFunSpec(JsonApiConstants.Members.RELATIONSHIPS_LINKS, relationshipsLinks.canonicalName))
                         }
 
                         if (rootMeta != null) {

--- a/processor/src/main/java/com/infinum/jsonapix/processor/specs/JsonApiXSpecBuilder.kt
+++ b/processor/src/main/java/com/infinum/jsonapix/processor/specs/JsonApiXSpecBuilder.kt
@@ -3,7 +3,9 @@ package com.infinum.jsonapix.processor.specs
 import com.infinum.jsonapix.core.JsonApiX
 import com.infinum.jsonapix.core.common.JsonApiConstants
 import com.infinum.jsonapix.core.common.JsonApiConstants.withName
+import com.infinum.jsonapix.core.resources.DefaultLinks
 import com.infinum.jsonapix.core.resources.Meta
+import com.infinum.jsonapix.processor.LinksInfo
 import com.infinum.jsonapix.processor.MetaInfo
 import com.infinum.jsonapix.processor.extensions.appendIf
 import com.squareup.kotlinpoet.AnnotationSpec
@@ -16,9 +18,9 @@ import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.asClassName
+import kotlin.properties.Delegates
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
-import kotlin.properties.Delegates
 
 internal object JsonApiXSpecBuilder : BaseJsonApiXSpecBuilder() {
 
@@ -30,6 +32,7 @@ internal object JsonApiXSpecBuilder : BaseJsonApiXSpecBuilder() {
         isNullable: Boolean,
         type: String,
         metaInfo: MetaInfo?,
+        linksInfo: LinksInfo?
     ): FileSpec {
         val modelClassName = ClassName.bestGuess(className.canonicalName.withName(JsonApiConstants.Suffix.JSON_API_MODEL))
 
@@ -40,8 +43,15 @@ internal object JsonApiXSpecBuilder : BaseJsonApiXSpecBuilder() {
             JsonApiConstants.Prefix.RESOURCE_OBJECT.withName(className.simpleName)
         )
 
-        val properties = getBasePropertySpecs(metaInfo?.rootClassName ?: Meta::class.asClassName()).toMutableList()
-        val params = getBaseParamSpecs(metaInfo?.rootClassName ?: Meta::class.asClassName()).toMutableList()
+        val properties = getBasePropertySpecs(
+            metaClassName = metaInfo?.rootClassName ?: Meta::class.asClassName(),
+            rootLinksClassName = linksInfo?.rootLinks
+        ).toMutableList()
+
+        val params = getBaseParamSpecs(
+            metaClassName = metaInfo?.rootClassName ?: Meta::class.asClassName(),
+            rootLinksClassName = linksInfo?.rootLinks
+        ).toMutableList()
 
         params.add(
             ParameterSpec.builder(
@@ -74,6 +84,7 @@ internal object JsonApiXSpecBuilder : BaseJsonApiXSpecBuilder() {
                         originalProperty(
                             modelClassName,
                             metaInfo,
+                            linksInfo
                         )
                     )
                     .build()
@@ -93,21 +104,23 @@ internal object JsonApiXSpecBuilder : BaseJsonApiXSpecBuilder() {
     private fun originalProperty(
         modelClassName: ClassName,
         metaInfo: MetaInfo?,
+        linksInfo: LinksInfo?,
     ): PropertySpec {
 
         val getterFunSpec = FunSpec.builder("get()")
             .addStatement("val original = data?.original(included)".appendIf("!!") { isNullable.not() })
             .addStatement(
-                "val model = %T(%L,%L,%L,%L,%L,%L,%L,%L?.filterValues{ it != null }?.mapValues{ it.value as? %T } )",
+                "val model = %T(\n%L,\n%L,\n%L,\n%L%T },\n%L,\n%L,\n%L,\n%L%T } )",
                 modelClassName,
                 "original",
                 "links",
                 "data?.links",
-                "data?.relationshipsLinks()\n?.filterValues{ it != null }",
+                "data?.relationshipsLinks()?.filterValues{ it != null }?.mapValues{ it.value as? ",
+                linksInfo?.relationshipsLinks ?: DefaultLinks::class,
                 "errors",
                 "meta",
                 "data?.meta",
-                "data?.relationshipsMeta()",
+                "data?.relationshipsMeta()?.filterValues{ it != null }?.mapValues{ it.value as? ",
                 metaInfo?.relationshipsClassNAme ?: Meta::class
             )
             .addStatement("return model")

--- a/processor/src/main/java/com/infinum/jsonapix/processor/specs/ResourceObjectSpecBuilder.kt
+++ b/processor/src/main/java/com/infinum/jsonapix/processor/specs/ResourceObjectSpecBuilder.kt
@@ -4,10 +4,11 @@ import com.infinum.jsonapix.core.common.JsonApiConstants
 import com.infinum.jsonapix.core.common.JsonApiConstants.withName
 import com.infinum.jsonapix.core.common.JsonApiXMissingArgumentException
 import com.infinum.jsonapix.core.resources.Attributes
-import com.infinum.jsonapix.core.resources.Links
+import com.infinum.jsonapix.core.resources.DefaultLinks
 import com.infinum.jsonapix.core.resources.Meta
 import com.infinum.jsonapix.core.resources.Relationships
 import com.infinum.jsonapix.core.resources.ResourceObject
+import com.infinum.jsonapix.processor.LinksInfo
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
@@ -29,6 +30,7 @@ internal object ResourceObjectSpecBuilder {
     fun build(
         className: ClassName,
         metaClassName: ClassName?,
+        linksInfo: LinksInfo?,
         type: String,
         attributes: List<PropertySpec>,
         oneRelationships: Map<String, TypeName>,
@@ -119,13 +121,13 @@ internal object ResourceObjectSpecBuilder {
         paramsList.add(
             Specs.getNullParamSpec(
                 JsonApiConstants.Keys.LINKS,
-                Links::class.asClassName().copy(nullable = true)
+                linksInfo?.resourceObjectLinks?.copy(nullable = true) ?: DefaultLinks::class.asClassName().copy(nullable = true)
             )
         )
         propsList.add(
             Specs.getNullPropertySpec(
                 JsonApiConstants.Keys.LINKS,
-                Links::class.asClassName().copy(nullable = true)
+                linksInfo?.resourceObjectLinks?.copy(nullable = true) ?: DefaultLinks::class.asClassName().copy(nullable = true)
             )
         )
 

--- a/processor/src/main/java/com/infinum/jsonapix/processor/specs/jsonxextensions/JsonXExtensionsSpecBuilder.kt
+++ b/processor/src/main/java/com/infinum/jsonapix/processor/specs/jsonxextensions/JsonXExtensionsSpecBuilder.kt
@@ -2,6 +2,7 @@ package com.infinum.jsonapix.processor.specs.jsonxextensions
 
 import com.infinum.jsonapix.core.common.JsonApiConstants
 import com.infinum.jsonapix.processor.ClassInfo
+import com.infinum.jsonapix.processor.LinksInfo
 import com.infinum.jsonapix.processor.MetaInfo
 import com.infinum.jsonapix.processor.specs.jsonxextensions.funspecbuilders.DeserializeFunSpecBuilder
 import com.infinum.jsonapix.processor.specs.jsonxextensions.funspecbuilders.DeserializeListFunSpecBuilder
@@ -40,6 +41,7 @@ internal class JsonXExtensionsSpecBuilder {
     fun add(
         type: String,
         metaInfo: MetaInfo?,
+        linksInfo: LinksInfo?,
         isNullable: Boolean,
         data: ClassName,
         wrapper: ClassName,
@@ -53,6 +55,7 @@ internal class JsonXExtensionsSpecBuilder {
         specsMap[data] = ClassInfo(
             type = type,
             metaInfo = metaInfo,
+            linksInfo = linksInfo,
             isNullable = isNullable,
             jsonWrapperClassName = wrapper,
             jsonWrapperListClassName = wrapperList,
@@ -160,7 +163,8 @@ internal class JsonXExtensionsSpecBuilder {
                     it.value.resourceObjectClassName,
                     it.value.attributesWrapperClassName,
                     it.value.relationshipsObjectClassName,
-                    it.value.metaInfo?.resourceObjectClassName
+                    it.value.metaInfo?.resourceObjectClassName,
+                    it.value.linksInfo?.resourceObjectLinks
                 )
             )
             fileSpec.addFunction(

--- a/processor/src/main/java/com/infinum/jsonapix/processor/specs/jsonxextensions/funspecbuilders/OriginalDataResourceObjectFunSpecBuilder.kt
+++ b/processor/src/main/java/com/infinum/jsonapix/processor/specs/jsonxextensions/funspecbuilders/OriginalDataResourceObjectFunSpecBuilder.kt
@@ -1,6 +1,7 @@
 package com.infinum.jsonapix.processor.specs.jsonxextensions.funspecbuilders
 
 import com.infinum.jsonapix.core.common.JsonApiConstants
+import com.infinum.jsonapix.core.resources.DefaultLinks
 import com.infinum.jsonapix.core.resources.Links
 import com.infinum.jsonapix.core.resources.Meta
 import com.squareup.kotlinpoet.ClassName
@@ -14,6 +15,7 @@ internal object OriginalDataResourceObjectFunSpecBuilder {
         attributesClass: ClassName?,
         relationshipsClass: ClassName?,
         resourceMeta: ClassName?,
+        resourceLinksClass: ClassName?
     ): FunSpec {
 
         val returnStatement = StringBuilder("return %T(")
@@ -39,8 +41,11 @@ internal object OriginalDataResourceObjectFunSpecBuilder {
         builderArgs.add(
             resourceMeta ?: Meta::class
         )
-        returnStatement.append("links = links")
 
+        returnStatement.append("links = links as? %T")
+        builderArgs.add(
+            resourceLinksClass ?: DefaultLinks::class
+        )
         returnStatement.append(")")
 
         return FunSpec.builder(JsonApiConstants.Members.TO_RESOURCE_OBJECT)

--- a/processor/src/main/java/com/infinum/jsonapix/processor/specs/model/JsonApiListItemSpecBuilder.kt
+++ b/processor/src/main/java/com/infinum/jsonapix/processor/specs/model/JsonApiListItemSpecBuilder.kt
@@ -1,7 +1,7 @@
 package com.infinum.jsonapix.processor.specs.model
 
 import com.infinum.jsonapix.core.common.JsonApiConstants
-import com.infinum.jsonapix.core.resources.Links
+import com.infinum.jsonapix.core.resources.DefaultLinks
 import com.infinum.jsonapix.core.resources.Meta
 import com.infinum.jsonapix.processor.LinksInfo
 import com.infinum.jsonapix.processor.MetaInfo
@@ -20,11 +20,13 @@ internal object JsonApiListItemSpecBuilder : BaseJsonApiModelSpecBuilder() {
                 isRootNullable,
                 JsonApiConstants.Defaults.NULL.takeIf { isRootNullable }
             ),
-            JsonApiConstants.Members.RESOURCE_OBJECT_LINKS.asParam(Links::class.asClassName(), true, JsonApiConstants.Defaults.NULL),
+            JsonApiConstants.Members.RESOURCE_OBJECT_LINKS.asParam(
+                linksInfo?.resourceObjectLinks ?: DefaultLinks::class.asClassName(), true, JsonApiConstants.Defaults.NULL
+            ),
             JsonApiConstants.Members.RELATIONSHIPS_LINKS.asParam(
                 Map::class.asClassName().parameterizedBy(
                     String::class.asClassName(),
-                    Links::class.asClassName().copy(nullable = true),
+                    linksInfo?.relationshipsLinks?.copy(nullable = true) ?: DefaultLinks::class.asClassName().copy(nullable = true),
                 ),
                 true,
                 JsonApiConstants.Defaults.EMPTY_MAP

--- a/processor/src/main/java/com/infinum/jsonapix/processor/specs/model/JsonApiModelSpecBuilder.kt
+++ b/processor/src/main/java/com/infinum/jsonapix/processor/specs/model/JsonApiModelSpecBuilder.kt
@@ -1,8 +1,8 @@
 package com.infinum.jsonapix.processor.specs.model
 
 import com.infinum.jsonapix.core.common.JsonApiConstants
+import com.infinum.jsonapix.core.resources.DefaultLinks
 import com.infinum.jsonapix.core.resources.Error
-import com.infinum.jsonapix.core.resources.Links
 import com.infinum.jsonapix.core.resources.Meta
 import com.infinum.jsonapix.processor.LinksInfo
 import com.infinum.jsonapix.processor.MetaInfo
@@ -21,23 +21,31 @@ internal object JsonApiModelSpecBuilder : BaseJsonApiModelSpecBuilder() {
                 isRootNullable,
                 JsonApiConstants.Defaults.NULL.takeIf { isRootNullable }
             ),
-            JsonApiConstants.Members.ROOT_LINKS.asParam(Links::class.asClassName(), true, JsonApiConstants.Defaults.NULL),
-            JsonApiConstants.Members.RESOURCE_OBJECT_LINKS.asParam(Links::class.asClassName(), true, JsonApiConstants.Defaults.NULL),
+            JsonApiConstants.Members.ROOT_LINKS.asParam(
+                linksInfo?.rootLinks ?: DefaultLinks::class.asClassName(),
+                true,
+                JsonApiConstants.Defaults.NULL
+            )
+            ,
+            JsonApiConstants.Members.RESOURCE_OBJECT_LINKS.asParam(
+                linksInfo?.resourceObjectLinks ?: DefaultLinks::class.asClassName(),
+                true,
+                JsonApiConstants.Defaults.NULL
+            )
+            ,
             JsonApiConstants.Members.RELATIONSHIPS_LINKS.asParam(
                 Map::class.asClassName().parameterizedBy(
                     String::class.asClassName(),
-                    Links::class.asClassName().copy(nullable = true),
+                    linksInfo?.relationshipsLinks?.copy(nullable = true) ?: DefaultLinks::class.asClassName().copy(nullable = true),
                 ),
                 true,
                 JsonApiConstants.Defaults.EMPTY_MAP,
             ),
-
             JsonApiConstants.Keys.ERRORS.asParam(
                 List::class.asClassName().parameterizedBy(Error::class.asClassName()),
                 true,
                 JsonApiConstants.Defaults.NULL,
             ),
-
             JsonApiConstants.Members.ROOT_META.asParam(
                 metaInfo?.rootClassName ?: Meta::class.asClassName(),
                 true,
@@ -55,7 +63,7 @@ internal object JsonApiModelSpecBuilder : BaseJsonApiModelSpecBuilder() {
                 ),
                 true,
                 JsonApiConstants.Defaults.EMPTY_MAP,
-            ),
+            )
         )
     }
 }

--- a/sample/src/main/java/com/infinum/jsonapix/ui/examples/person/PersonViewModel.kt
+++ b/sample/src/main/java/com/infinum/jsonapix/ui/examples/person/PersonViewModel.kt
@@ -31,9 +31,9 @@ class PersonViewModel @Inject constructor(
                 viewState = PersonState(
                     bodyString,
                     person,
-                    (personModel.rootLinks as? DefaultLinks)?.self,
-                    (personModel.resourceObjectLinks as? DefaultLinks)?.self,
-                    (personModel.relationshipsLinks?.values?.firstOrNull() as? DefaultLinks)?.self,
+                    personModel.rootLinks?.self,
+                    personModel.resourceObjectLinks?.self,
+                    personModel.relationshipsLinks?.values?.firstOrNull()?.self,
                     personModel.rootMeta?.owner
                 )
             } catch (t: Throwable) {


### PR DESCRIPTION
[Task](https://app.productive.io/1-infinum/dashboards/48984/task/6943166)

Now the generate model will inherit form the custom link classes which the user has specified(for all placements). If there are no custom classes, the model will instead inherit form the `DefaultLink` class. 

With this change multiple gemerated files needed to make this change as well(`JsonApiXList_`, `JsonApiX_`, `ResourceObject_`,`JsonXExtensions`) so this is done in their spec builders.

The project builds normally and I tested the serialisation/deserialisation of the person model in the sample view model.