### PR TITLE
Inherit from custom/default error when building main model class

### DIFF
--- a/processor/src/main/java/com/infinum/jsonapix/processor/JsonApiProcessor.kt
+++ b/processor/src/main/java/com/infinum/jsonapix/processor/JsonApiProcessor.kt
@@ -170,6 +170,7 @@ public class JsonApiProcessor : AbstractProcessor() {
 
         val metaInfo = customMetas.firstOrNull { it.type == type }
         val linksInfo = customLinks.firstOrNull { it.type == type }
+        val customError = customErrors[type]
 
         collector.add(
             type = type,
@@ -194,7 +195,6 @@ public class JsonApiProcessor : AbstractProcessor() {
 
         adapterFactoryCollector.add(inputDataClass)
 
-
         val resourceFileSpec =
             ResourceObjectSpecBuilder.build(
                 className = inputDataClass,
@@ -206,14 +206,11 @@ public class JsonApiProcessor : AbstractProcessor() {
                 manyRelationships = mapOf(*manyRelationships.map { it.name to it.type }.toTypedArray())
             )
 
-
-        val wrapperFileSpec =
-            JsonApiXSpecBuilder.build(inputDataClass, isNullable, type, metaInfo, linksInfo)
-        val wrapperListFileSpec =
-            JsonApiXListSpecBuilder.build(inputDataClass, isNullable, type, metaInfo, linksInfo)
-        val modelFileSpec = JsonApiModelSpecBuilder.build(inputDataClass, isNullable, metaInfo, linksInfo)
-        val listItemFileSpec = JsonApiListItemSpecBuilder.build(inputDataClass, isNullable, metaInfo, linksInfo)
-        val listFileSpec = JsonApiListSpecBuilder.build(inputDataClass, isNullable, metaInfo, linksInfo)
+        val wrapperFileSpec = JsonApiXSpecBuilder.build(inputDataClass, isNullable, type, metaInfo, linksInfo, customError)
+        val wrapperListFileSpec = JsonApiXListSpecBuilder.build(inputDataClass, isNullable, type, metaInfo, linksInfo, customError)
+        val modelFileSpec = JsonApiModelSpecBuilder.build(inputDataClass, isNullable, metaInfo, linksInfo, customError)
+        val listItemFileSpec = JsonApiListItemSpecBuilder.build(inputDataClass, isNullable, metaInfo, linksInfo, customError)
+        val listFileSpec = JsonApiListSpecBuilder.build(inputDataClass, isNullable, metaInfo, linksInfo, customError)
 
         val typeAdapterFileSpec = TypeAdapterSpecBuilder.build(
             className = inputDataClass,
@@ -223,7 +220,7 @@ public class JsonApiProcessor : AbstractProcessor() {
             rootMeta = metaInfo?.rootClassName,
             resourceObjectMeta = metaInfo?.resourceObjectClassName,
             relationshipsMeta = metaInfo?.relationshipsClassNAme,
-            errors = customErrors[type]?.canonicalName
+            errors = customError?.canonicalName
         )
 
         val typeAdapterListFileSpec = TypeAdapterListSpecBuilder.build(
@@ -234,7 +231,7 @@ public class JsonApiProcessor : AbstractProcessor() {
             rootMeta = metaInfo?.rootClassName,
             resourceObjectMeta = metaInfo?.resourceObjectClassName,
             relationshipsMeta = metaInfo?.relationshipsClassNAme,
-            errors = customErrors[type]?.canonicalName
+            errors = customError?.canonicalName
         )
 
         resourceFileSpec.writeTo(File(kaptKotlinGeneratedDir!!))

--- a/processor/src/main/java/com/infinum/jsonapix/processor/specs/JsonApiXListSpecBuilder.kt
+++ b/processor/src/main/java/com/infinum/jsonapix/processor/specs/JsonApiXListSpecBuilder.kt
@@ -29,7 +29,8 @@ internal object JsonApiXListSpecBuilder : BaseJsonApiXSpecBuilder() {
         isNullable: Boolean,
         type: String,
         metaInfo: MetaInfo?,
-        linksInfo: LinksInfo?
+        linksInfo: LinksInfo?,
+        customError: ClassName?
     ): FileSpec {
         val modelClassName = ClassName.bestGuess(className.canonicalName.withName(JsonApiConstants.Suffix.JSON_API_LIST))
         val itemClassName = ClassName.bestGuess(className.canonicalName.withName(JsonApiConstants.Suffix.JSON_API_LIST_ITEM))
@@ -42,12 +43,14 @@ internal object JsonApiXListSpecBuilder : BaseJsonApiXSpecBuilder() {
 
         val properties = getBasePropertySpecs(
             metaClassName = metaInfo?.rootClassName ?: Meta::class.asClassName(),
-            rootLinksClassName = linksInfo?.rootLinks
+            rootLinksClassName = linksInfo?.rootLinks,
+            customError = customError
         ).toMutableList()
 
         val params = getBaseParamSpecs(
             metaClassName = metaInfo?.rootClassName ?: Meta::class.asClassName(),
-            rootLinksClassName = linksInfo?.rootLinks
+            rootLinksClassName = linksInfo?.rootLinks,
+            customError = customError
         ).toMutableList()
 
         params.add(

--- a/processor/src/main/java/com/infinum/jsonapix/processor/specs/JsonApiXSpecBuilder.kt
+++ b/processor/src/main/java/com/infinum/jsonapix/processor/specs/JsonApiXSpecBuilder.kt
@@ -32,7 +32,8 @@ internal object JsonApiXSpecBuilder : BaseJsonApiXSpecBuilder() {
         isNullable: Boolean,
         type: String,
         metaInfo: MetaInfo?,
-        linksInfo: LinksInfo?
+        linksInfo: LinksInfo?,
+        customError: ClassName?
     ): FileSpec {
         val modelClassName = ClassName.bestGuess(className.canonicalName.withName(JsonApiConstants.Suffix.JSON_API_MODEL))
 
@@ -45,12 +46,14 @@ internal object JsonApiXSpecBuilder : BaseJsonApiXSpecBuilder() {
 
         val properties = getBasePropertySpecs(
             metaClassName = metaInfo?.rootClassName ?: Meta::class.asClassName(),
-            rootLinksClassName = linksInfo?.rootLinks
+            rootLinksClassName = linksInfo?.rootLinks,
+            customError = customError
         ).toMutableList()
 
         val params = getBaseParamSpecs(
             metaClassName = metaInfo?.rootClassName ?: Meta::class.asClassName(),
-            rootLinksClassName = linksInfo?.rootLinks
+            rootLinksClassName = linksInfo?.rootLinks,
+            customError = customError
         ).toMutableList()
 
         params.add(

--- a/processor/src/main/java/com/infinum/jsonapix/processor/specs/model/BaseJsonApiModelSpecBuilder.kt
+++ b/processor/src/main/java/com/infinum/jsonapix/processor/specs/model/BaseJsonApiModelSpecBuilder.kt
@@ -20,18 +20,20 @@ internal abstract class BaseJsonApiModelSpecBuilder {
         className: ClassName,
         isRootNullable: Boolean,
         metaInfo: MetaInfo?,
-        linksInfo: LinksInfo?
+        linksInfo: LinksInfo?,
+        customError: ClassName?
     ): List<ParameterSpec>
 
     fun build(
         className: ClassName,
         isRootNullable: Boolean,
         metaInfo: MetaInfo?,
-        linksInfo: LinksInfo?
+        linksInfo: LinksInfo?,
+        customError: ClassName?
     ): FileSpec {
         val generatedName = className.simpleName.withName(getClassSuffixName())
 
-        val params = getParams(className, isRootNullable, metaInfo, linksInfo)
+        val params = getParams(className, isRootNullable, metaInfo, linksInfo, customError)
         val props = params.map { it.toPropSpec() }
 
         return FileSpec.builder(className.packageName, generatedName)

--- a/processor/src/main/java/com/infinum/jsonapix/processor/specs/model/JsonApiListItemSpecBuilder.kt
+++ b/processor/src/main/java/com/infinum/jsonapix/processor/specs/model/JsonApiListItemSpecBuilder.kt
@@ -13,36 +13,44 @@ import com.squareup.kotlinpoet.asClassName
 internal object JsonApiListItemSpecBuilder : BaseJsonApiModelSpecBuilder() {
     override fun getClassSuffixName(): String = JsonApiConstants.Suffix.JSON_API_LIST_ITEM
     override fun getRootClassName(rootType: ClassName): ClassName = rootType
-    override fun getParams(className: ClassName, isRootNullable: Boolean, metaInfo: MetaInfo?, linksInfo: LinksInfo?): List<ParameterSpec> {
+    override fun getParams(
+        className: ClassName,
+        isRootNullable: Boolean,
+        metaInfo: MetaInfo?,
+        linksInfo: LinksInfo?,
+        customError: ClassName?
+    ): List<ParameterSpec> {
         return listOf(
             JsonApiConstants.Keys.DATA.asParam(
-                getRootClassName(className),
-                isRootNullable,
-                JsonApiConstants.Defaults.NULL.takeIf { isRootNullable }
+                className = getRootClassName(className),
+                isNullable = isRootNullable,
+                defaultValue = JsonApiConstants.Defaults.NULL.takeIf { isRootNullable }
             ),
             JsonApiConstants.Members.RESOURCE_OBJECT_LINKS.asParam(
-                linksInfo?.resourceObjectLinks ?: DefaultLinks::class.asClassName(), true, JsonApiConstants.Defaults.NULL
+                className = linksInfo?.resourceObjectLinks ?: DefaultLinks::class.asClassName(),
+                isNullable = true,
+                defaultValue = JsonApiConstants.Defaults.NULL
             ),
             JsonApiConstants.Members.RELATIONSHIPS_LINKS.asParam(
-                Map::class.asClassName().parameterizedBy(
+                className = Map::class.asClassName().parameterizedBy(
                     String::class.asClassName(),
                     linksInfo?.relationshipsLinks?.copy(nullable = true) ?: DefaultLinks::class.asClassName().copy(nullable = true),
                 ),
-                true,
-                JsonApiConstants.Defaults.EMPTY_MAP
+                isNullable = true,
+                defaultValue = JsonApiConstants.Defaults.EMPTY_MAP
             ),
             JsonApiConstants.Members.RESOURCE_OBJECT_META.asParam(
-                metaInfo?.resourceObjectClassName ?: Meta::class.asClassName(),
-                true,
-                JsonApiConstants.Defaults.NULL
+                className = metaInfo?.resourceObjectClassName ?: Meta::class.asClassName(),
+                isNullable = true,
+                defaultValue = JsonApiConstants.Defaults.NULL
             ),
             JsonApiConstants.Members.RELATIONSHIPS_META.asParam(
-                Map::class.asClassName().parameterizedBy(
+                className = Map::class.asClassName().parameterizedBy(
                     String::class.asClassName(),
                     metaInfo?.relationshipsClassNAme?.copy(nullable = true) ?: Meta::class.asClassName().copy(nullable = true),
                 ),
-                true,
-                JsonApiConstants.Defaults.EMPTY_MAP
+                isNullable = true,
+                defaultValue = JsonApiConstants.Defaults.EMPTY_MAP
             ),
         )
     }

--- a/processor/src/main/java/com/infinum/jsonapix/processor/specs/model/JsonApiListSpecBuilder.kt
+++ b/processor/src/main/java/com/infinum/jsonapix/processor/specs/model/JsonApiListSpecBuilder.kt
@@ -2,8 +2,8 @@ package com.infinum.jsonapix.processor.specs.model
 
 import com.infinum.jsonapix.core.common.JsonApiConstants
 import com.infinum.jsonapix.core.common.JsonApiConstants.withName
+import com.infinum.jsonapix.core.resources.DefaultError
 import com.infinum.jsonapix.core.resources.DefaultLinks
-import com.infinum.jsonapix.core.resources.Error
 import com.infinum.jsonapix.core.resources.Meta
 import com.infinum.jsonapix.processor.LinksInfo
 import com.infinum.jsonapix.processor.MetaInfo
@@ -21,7 +21,13 @@ internal object JsonApiListSpecBuilder : BaseJsonApiModelSpecBuilder() {
         return List::class.asClassName().parameterizedBy(itemType)
     }
 
-    override fun getParams(className: ClassName, isRootNullable: Boolean, metaInfo: MetaInfo?, linksInfo: LinksInfo?): List<ParameterSpec> {
+    override fun getParams(
+        className: ClassName,
+        isRootNullable: Boolean,
+        metaInfo: MetaInfo?,
+        linksInfo: LinksInfo?,
+        customError: ClassName?
+    ): List<ParameterSpec> {
         return listOf(
             JsonApiConstants.Keys.DATA.asParam(
                 className = getRootClassName(className),
@@ -34,7 +40,7 @@ internal object JsonApiListSpecBuilder : BaseJsonApiModelSpecBuilder() {
                 defaultValue = JsonApiConstants.Defaults.NULL
             ),
             JsonApiConstants.Keys.ERRORS.asParam(
-                className = List::class.asClassName().parameterizedBy(Error::class.asClassName()),
+                className = List::class.asClassName().parameterizedBy(customError ?: DefaultError::class.asClassName()),
                 isNullable = true,
                 defaultValue = JsonApiConstants.Defaults.NULL
             ),

--- a/processor/src/main/java/com/infinum/jsonapix/processor/specs/model/JsonApiModelSpecBuilder.kt
+++ b/processor/src/main/java/com/infinum/jsonapix/processor/specs/model/JsonApiModelSpecBuilder.kt
@@ -1,8 +1,8 @@
 package com.infinum.jsonapix.processor.specs.model
 
 import com.infinum.jsonapix.core.common.JsonApiConstants
+import com.infinum.jsonapix.core.resources.DefaultError
 import com.infinum.jsonapix.core.resources.DefaultLinks
-import com.infinum.jsonapix.core.resources.Error
 import com.infinum.jsonapix.core.resources.Meta
 import com.infinum.jsonapix.processor.LinksInfo
 import com.infinum.jsonapix.processor.MetaInfo
@@ -14,55 +14,59 @@ import com.squareup.kotlinpoet.asClassName
 internal object JsonApiModelSpecBuilder : BaseJsonApiModelSpecBuilder() {
     override fun getClassSuffixName(): String = JsonApiConstants.Suffix.JSON_API_MODEL
     override fun getRootClassName(rootType: ClassName): ClassName = rootType
-    override fun getParams(className: ClassName, isRootNullable: Boolean, metaInfo: MetaInfo?, linksInfo: LinksInfo?): List<ParameterSpec> {
+    override fun getParams(
+        className: ClassName,
+        isRootNullable: Boolean,
+        metaInfo: MetaInfo?,
+        linksInfo: LinksInfo?,
+        customError: ClassName?
+    ): List<ParameterSpec> {
         return listOf(
             JsonApiConstants.Keys.DATA.asParam(
-                getRootClassName(className),
-                isRootNullable,
-                JsonApiConstants.Defaults.NULL.takeIf { isRootNullable }
+                className = getRootClassName(className),
+                isNullable = isRootNullable,
+                defaultValue = JsonApiConstants.Defaults.NULL.takeIf { isRootNullable }
             ),
             JsonApiConstants.Members.ROOT_LINKS.asParam(
-                linksInfo?.rootLinks ?: DefaultLinks::class.asClassName(),
-                true,
-                JsonApiConstants.Defaults.NULL
-            )
-            ,
+                className = linksInfo?.rootLinks ?: DefaultLinks::class.asClassName(),
+                isNullable = true,
+                defaultValue = JsonApiConstants.Defaults.NULL
+            ),
             JsonApiConstants.Members.RESOURCE_OBJECT_LINKS.asParam(
-                linksInfo?.resourceObjectLinks ?: DefaultLinks::class.asClassName(),
-                true,
-                JsonApiConstants.Defaults.NULL
-            )
-            ,
+                className = linksInfo?.resourceObjectLinks ?: DefaultLinks::class.asClassName(),
+                isNullable = true,
+                defaultValue = JsonApiConstants.Defaults.NULL
+            ),
             JsonApiConstants.Members.RELATIONSHIPS_LINKS.asParam(
-                Map::class.asClassName().parameterizedBy(
+                className = Map::class.asClassName().parameterizedBy(
                     String::class.asClassName(),
                     linksInfo?.relationshipsLinks?.copy(nullable = true) ?: DefaultLinks::class.asClassName().copy(nullable = true),
                 ),
-                true,
-                JsonApiConstants.Defaults.EMPTY_MAP,
+                isNullable = true,
+                defaultValue = JsonApiConstants.Defaults.EMPTY_MAP,
             ),
             JsonApiConstants.Keys.ERRORS.asParam(
-                List::class.asClassName().parameterizedBy(Error::class.asClassName()),
-                true,
-                JsonApiConstants.Defaults.NULL,
+                className = List::class.asClassName().parameterizedBy(customError ?: DefaultError::class.asClassName()),
+                isNullable = true,
+                defaultValue = JsonApiConstants.Defaults.NULL,
             ),
             JsonApiConstants.Members.ROOT_META.asParam(
-                metaInfo?.rootClassName ?: Meta::class.asClassName(),
-                true,
-                JsonApiConstants.Defaults.NULL,
+                className = metaInfo?.rootClassName ?: Meta::class.asClassName(),
+                isNullable = true,
+                defaultValue = JsonApiConstants.Defaults.NULL,
             ),
             JsonApiConstants.Members.RESOURCE_OBJECT_META.asParam(
-                metaInfo?.resourceObjectClassName ?: Meta::class.asClassName(),
-                true,
-                JsonApiConstants.Defaults.NULL,
+                className = metaInfo?.resourceObjectClassName ?: Meta::class.asClassName(),
+                isNullable = true,
+                defaultValue = JsonApiConstants.Defaults.NULL,
             ),
             JsonApiConstants.Members.RELATIONSHIPS_META.asParam(
-                Map::class.asClassName().parameterizedBy(
+                className = Map::class.asClassName().parameterizedBy(
                     String::class.asClassName(),
                     metaInfo?.relationshipsClassNAme?.copy(nullable = true) ?: Meta::class.asClassName().copy(nullable = true),
                 ),
-                true,
-                JsonApiConstants.Defaults.EMPTY_MAP,
+                isNullable = true,
+                defaultValue = JsonApiConstants.Defaults.EMPTY_MAP,
             )
         )
     }


### PR DESCRIPTION
[Task](https://app.productive.io/1-infinum/dashboards/48984/task/6949621)

Now the generated classes inherit from the custom error class if it exists, if not `List<DefaultLink>` is used instead. 

This was much simpler then using custom links, as errors are used less in generated classes then links.