### PR TITLE
Add support for generic error handling

### DIFF
--- a/core/src/main/java/com/infinum/jsonapix/core/common/JsonApiConstants.kt
+++ b/core/src/main/java/com/infinum/jsonapix/core/common/JsonApiConstants.kt
@@ -63,6 +63,8 @@ object JsonApiConstants {
         const val PARSE_TO_JSON_ELEMENT = "parseToJsonElement"
         const val JSONX_SERIALIZER_MODULE = "jsonApiXSerializerModule"
         const val AS_JSON_X_HTTP_EXCEPTION = "asJsonXHttpException"
+        const val DECODE_JSON_API_ERROR = "decodeJsonApiError"
+        const val ERROR_BODY = "errorBody"
 
         const val TO_ONE_RELATIONSHIP_MODEL = "toOneRelationshipModel"
         const val TO_MANY_RELATIONSHIP_MODEL = "toManyRelationshipModel"

--- a/core/src/main/java/com/infinum/jsonapix/core/resources/DefaultError.kt
+++ b/core/src/main/java/com/infinum/jsonapix/core/resources/DefaultError.kt
@@ -6,8 +6,8 @@ import kotlinx.serialization.Serializable
 @Serializable
 @SerialName("error")
 class DefaultError(
-    @SerialName("code") val code: String,
-    @SerialName("title") val title: String,
-    @SerialName("detail") val detail: String,
-    @SerialName("status") val status: String
+    @SerialName("code") val code: String? = null,
+    @SerialName("title") val title: String? = null,
+    @SerialName("detail") val detail: String? = null,
+    @SerialName("status") val status: String? = null,
 ) : Error

--- a/processor/src/main/java/com/infinum/jsonapix/processor/specs/jsonxextensions/JsonXExtensionsSpecBuilder.kt
+++ b/processor/src/main/java/com/infinum/jsonapix/processor/specs/jsonxextensions/JsonXExtensionsSpecBuilder.kt
@@ -24,6 +24,7 @@ import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.asTypeName
@@ -89,7 +90,7 @@ internal class JsonXExtensionsSpecBuilder {
 
         return FunSpec.builder(JsonApiConstants.Members.AS_JSON_X_HTTP_EXCEPTION)
             .receiver(HttpException::class)
-            .returns(JsonXHttpException::class)
+            .returns(JsonXHttpException::class.asClassName().parameterizedBy(typeVariableName))
             .addModifiers(KModifier.INLINE)
             .addTypeVariable(
                 typeVariableName.copy(

--- a/processor/src/main/java/com/infinum/jsonapix/processor/specs/jsonxextensions/JsonXExtensionsSpecBuilder.kt
+++ b/processor/src/main/java/com/infinum/jsonapix/processor/specs/jsonxextensions/JsonXExtensionsSpecBuilder.kt
@@ -98,11 +98,14 @@ internal class JsonXExtensionsSpecBuilder {
                     bounds = listOf(com.infinum.jsonapix.core.resources.Error::class.asTypeName())
                 )
             )
+            .beginControlFlow("try")
             .addStatement(
                 "return %T(response(), response()?.errorBody()?.charStream()?.readText()?.let { " +
                     "format.decodeFromString<Errors<${JsonApiConstants.Members.GENERIC_TYPE_VARIABLE}>>(it) }?.errors)",
                 JsonXHttpException::class.asClassName()
-            )
+            ).nextControlFlow("catch (e: %T)", IllegalArgumentException::class.asClassName())
+            .addStatement("return %T(response(),emptyList())", JsonXHttpException::class.asClassName())
+            .endControlFlow()
             .build()
     }
 

--- a/retrofit/src/main/java/com/infinum/jsonapix/retrofit/JsonXHttpException.kt
+++ b/retrofit/src/main/java/com/infinum/jsonapix/retrofit/JsonXHttpException.kt
@@ -1,17 +1,6 @@
 package com.infinum.jsonapix.retrofit
 
-import com.infinum.jsonapix.core.resources.DefaultErrors
 import com.infinum.jsonapix.core.resources.Error
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.json.Json
-import retrofit2.HttpException
 import retrofit2.Response
 
-data class  JsonXHttpException <T: Error> (val response: Response<*>?, val errors: List<T>?)
-
-fun HttpException.asJsonXHttpException(): JsonXHttpException {
-    return JsonXHttpException(
-        response(),
-        response()?.errorBody()?.charStream()?.readText()?.let { Json.decodeFromString<DefaultErrors>(it) }?.errors
-    )
-}
+data class JsonXHttpException<T : Error>(val response: Response<*>?, val errors: List<T>?)

--- a/retrofit/src/main/java/com/infinum/jsonapix/retrofit/JsonXHttpException.kt
+++ b/retrofit/src/main/java/com/infinum/jsonapix/retrofit/JsonXHttpException.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.json.Json
 import retrofit2.HttpException
 import retrofit2.Response
 
-data class JsonXHttpException(val response: Response<*>?, val errors: List<Error>?)
+data class  JsonXHttpException <T: Error> (val response: Response<*>?, val errors: List<T>?)
 
 fun HttpException.asJsonXHttpException(): JsonXHttpException {
     return JsonXHttpException(

--- a/sample/src/main/java/com/infinum/jsonapix/ui/examples/error/ErrorViewModel.kt
+++ b/sample/src/main/java/com/infinum/jsonapix/ui/examples/error/ErrorViewModel.kt
@@ -1,13 +1,14 @@
 package com.infinum.jsonapix.ui.examples.error
 
 import com.infinum.jsonapix.asJsonXHttpException
+import com.infinum.jsonapix.core.resources.DefaultError
 import com.infinum.jsonapix.data.api.SampleApiService
 import com.infinum.jsonapix.data.assets.JsonAssetReader
 import com.infinum.jsonapix.data.models.PersonalError
 import com.infinum.jsonapix.ui.shared.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
 import retrofit2.HttpException
+import javax.inject.Inject
 
 @HiltViewModel
 class ErrorViewModel @Inject constructor(
@@ -23,13 +24,9 @@ class ErrorViewModel @Inject constructor(
             try {
                 val person = io { sampleApiService.fetchError() }
             } catch (e: HttpException) {
-                val exc = e.asJsonXHttpException<PersonalError>()
+                val exc = e.asJsonXHttpException<DefaultError>()
                 exc.errors?.first()?.let {
-                    if (it is PersonalError) {
-                        showError(it.desc)
-                    } else {
-                        showError("Not a default error")
-                    }
+                    showError(it.code)
                 } ?: showError("Unable to parse to JsonXHttpException")
             }
 

--- a/sample/src/main/java/com/infinum/jsonapix/ui/examples/error/ErrorViewModel.kt
+++ b/sample/src/main/java/com/infinum/jsonapix/ui/examples/error/ErrorViewModel.kt
@@ -24,9 +24,10 @@ class ErrorViewModel @Inject constructor(
             try {
                 val person = io { sampleApiService.fetchError() }
             } catch (e: HttpException) {
-                val exc = e.asJsonXHttpException<DefaultError>()
-                exc.errors?.first()?.let {
-                    showError(it.code)
+                val exc = e.asJsonXHttpException<PersonalError>()
+
+                exc.errors?.firstOrNull()?.let {
+                    showError(it.desc)
                 } ?: showError("Unable to parse to JsonXHttpException")
             }
 


### PR DESCRIPTION
[Task](https://app.productive.io/1-infinum/tasks/7014851)

- Make `asJsonXHttpException` type aware and return the type specified in the function
- Incase the specified error type is not right the function will return empty list
- Generate a new function `decodeJsonApiError` to decode error body, this function can be used with or without Retrofit