### PR TITLE
Implement support for repeatable Error, Links and Meta annotations

### DIFF
--- a/annotations/src/main/java/com/infinum/jsonapix/annotations/JsonApiXError.kt
+++ b/annotations/src/main/java/com/infinum/jsonapix/annotations/JsonApiXError.kt
@@ -6,4 +6,9 @@ package com.infinum.jsonapix.annotations
 @MustBeDocumented
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
+@JvmRepeatable(JsonApiXErrorList::class)
 annotation class JsonApiXError(val type: String)
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class JsonApiXErrorList(val value: Array<JsonApiXError>)

--- a/annotations/src/main/java/com/infinum/jsonapix/annotations/JsonApiXLinks.kt
+++ b/annotations/src/main/java/com/infinum/jsonapix/annotations/JsonApiXLinks.kt
@@ -3,10 +3,15 @@ package com.infinum.jsonapix.annotations
 @MustBeDocumented
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
+@JvmRepeatable(JsonApiXLinksList::class)
 annotation class JsonApiXLinks(
     val type: String,
     val placementStrategy: LinksPlacementStrategy = LinksPlacementStrategy.ROOT
 )
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class JsonApiXLinksList(val value: Array<JsonApiXLinks>)
 
 enum class LinksPlacementStrategy {
     ROOT, DATA, RELATIONSHIPS

--- a/annotations/src/main/java/com/infinum/jsonapix/annotations/JsonApiXMeta.kt
+++ b/annotations/src/main/java/com/infinum/jsonapix/annotations/JsonApiXMeta.kt
@@ -3,10 +3,15 @@ package com.infinum.jsonapix.annotations
 @MustBeDocumented
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
+@JvmRepeatable(JsonApiXMetaList::class)
 annotation class JsonApiXMeta(
     val type: String,
     val placementStrategy: MetaPlacementStrategy = MetaPlacementStrategy.ROOT,
 )
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class JsonApiXMetaList(val value: Array<JsonApiXMeta>)
 
 enum class MetaPlacementStrategy {
     ROOT, DATA, RELATIONSHIPS

--- a/processor/src/main/java/com/infinum/jsonapix/processor/extensions/AnnotationExtensions.kt
+++ b/processor/src/main/java/com/infinum/jsonapix/processor/extensions/AnnotationExtensions.kt
@@ -11,6 +11,10 @@ public inline fun <reified T : Annotation, reified R : Any> Element.getAnnotatio
     f: T.() -> R
 ): R = getAnnotation(T::class.java).f()
 
+public inline fun <reified T : Annotation, reified R : Any> Element.getAnnotationParameterValues(
+    f: Array<T>.() -> R
+): R = getAnnotationsByType(T::class.java).f()
+
 @SuppressWarnings("TooGenericExceptionThrown")
 public inline fun <reified T : Annotation> Element.getAnnotationClassValue(
     f: T.() -> KClass<*>


### PR DESCRIPTION
Added support for repeatable `Error`, `Links` and `Meta` annotations. 

It was not as straightforward as we maybe thought, as we need to define a separate "List" Annotation for each of our annotations which will store an array of repeated annotations. You can read more about it here if you want more info:
- https://kotlinlang.org/docs/annotations.html#repeatable-annotations
- https://github.com/Kotlin/KEEP/blob/master/proposals/repeatable-annotations.md

I also cleaned up the processing of each of these annotations so they all follow the same structure. 