### PR TITLE
Update repo to follow infinum open-source template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,54 @@
+name: Bug report
+description: Create a report to help us improve
+labels: bug
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: 📖 Description
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: ℹ️ Environment
+      description: |
+        An environment information where issue occurred. Try to provide as much information as possible, including:
+          - device name, model and manufacturer (e.g. Google Pixel 9)
+          - operating system version (e.g. Android 12)
+          - software name, version and build number (e.g The Library 4.2.1)
+          - additional information (e.g. dependencies, IDE, etc.)
+      value: |
+        - Device: 
+        - Operating system: 
+        - Software information: 
+        - Additional information: 
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: 💣 Steps to reproduce
+      description: Steps to reproduce the behavior.
+      value: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: 🔧 Expected behavior
+      description: A clear and concise description of what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: additional-information
+    attributes:
+      label: 📄 Additional information
+      description: Any additional information that might be helpful in solving the issue. Including screenshots, logs, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature request
+description: Propose a new feature or an idea for this project
+labels: enhancement
+body:
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: 💡 Feature description
+      description: A clear and concise description of the feature request, including what problem it solves.
+    validations:
+      required: true
+  - type: textarea
+    id: additional-information
+    attributes:
+      label: ℹ️ Additional information
+      description: An additional information or screenshots about the feature request.
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: 🤔 Describe alternatives you've considered
+      description: Can you think of alternative approaches to achieve same goal?
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,8 +4,7 @@
     Provide an overview of what this pull request aims to address or achieve.
 -->
 
-**Related issue
-**: <!-- Add the issue number in format [#<number>](link) or set to "None" if this is not related to a reported issue. -->
+**Related issue**: <!-- Add the issue number in format [#<number>](link) or set to "None" if this is not related to a reported issue. -->
 
 ## Changes
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,43 @@
+## Summary
+
+<!-- 
+    Provide an overview of what this pull request aims to address or achieve.
+-->
+
+**Related issue
+**: <!-- Add the issue number in format [#<number>](link) or set to "None" if this is not related to a reported issue. -->
+
+## Changes
+
+### Type
+
+- [ ] **Feature**: This pull request introduces a new feature.
+- [ ] **Bug fix**: This pull request fixes a bug.
+- [ ] **Refactor**: This pull request refactors existing code.
+- [ ] **Documentation**: This pull request updates documentation.
+- [ ] **Other**: This pull request makes other changes.
+
+#### Additional information
+
+- [ ] This pull request introduces a **breaking change**.
+
+### Description
+
+<!-- 
+    Describe the specific changes made in this pull request, including any technical details or architectural decisions. 
+
+    If applicable, include additional information like screenshots, logs or other data that demonstrate the changes. 
+-->
+
+## Checklist
+
+- [ ] I have performed a self-review of my own code.
+- [ ] I have tested my changes, including edge cases.
+- [ ] I have added necessary tests for the changes introduced (if applicable).
+- [ ] I have updated the documentation to reflect my changes (if applicable).
+
+## Additional notes
+
+<!-- 
+    Add any additional comments, instructions, or insights about this pull request. 
+-->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Code of conduct
+
+## Our pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at opensource@infinum.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 1.4,
+available [here](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html).
+
+For answers to common questions about this code of conduct, visit
+the [FAQ](https://www.contributor-covenant.org/faq) page.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing guidelines
+
+Welcome to our project! We appreciate your interest in helping us improve it.
+
+## How can I contribute?
+
+There are multiple ways in which you can help us make this project even better.
+
+- Reporting bugs or suggesting new features
+- Contributing code improvements or new features
+- Writing, updating, or fixing tests
+- Improving documentation, including inline comments, user manuals, and developer guides
+
+## Issue reporting
+
+If you found a bug or have an idea for a new feature, please open an issue. Be sure to include a clear and descriptive
+title, as well as a detailed description of the bug or feature.
+
+To avoid duplicate issues, please check if a similar issue has already been created.
+
+## Making changes
+
+To make changes to the project, please follow these steps:
+
+1. Fork the project repository.
+2. Create a new branch for your changes, based on the project's main branch.
+3. Make your changes. Ensure you've followed the coding style and standards.
+4. Test your changes thoroughly, ensuring all existing tests pass and new tests cover your changes where appropriate.
+5. Commit your changes with a clear and descriptive commit message.
+6. Push your changes to your fork.
+7. Create a pull request to the project's main branch.
+
+Once we check everything, we will merge the changes into the main branch and include it in the next release.
+
+## Guidelines for pull requests
+
+When submitting a pull request, please ensure that:
+
+- Your pull request is concise and well-scoped
+- Your code is properly tested
+- Your code adheres to the project's coding standards and style guidelines
+- Your commit message is clear and descriptive
+- Your pull request includes a description of the changes you have made and why you have made them
+
+Try to avoid creating large pull requests that include multiple unrelated changes. Instead, break them down into
+smaller, more focused pull requests. This will make it easier for us to review and merge your changes.
+
+## Code of conduct
+
+We want to ensure a welcoming environment for everyone. With that in mind, all contributors are expected to follow
+our [code of conduct](/CODE_OF_CONDUCT.md).
+
+## License
+
+By submitting a pull request you agree to release that code under the project's [license](/LICENSE).

--- a/README.md
+++ b/README.md
@@ -4,20 +4,25 @@
 ### <img align="left" src="logo.svg" width="48">
 # JsonApiX
 
+## Description
+
 - JSON API X is an Android, annotation processor library with the intention of extending it to a KMP library in due time
 - Implements a parser between Kotlin classes and JSON API specification strings in both directions
 - Includes Retrofit module for easy API implementations
 
-### List of libraries used in the project
+## Table of contents
 
-This chapter lists all the libraries that make a bigger contribution to the project. It is essential for any future contributor to get
-familiar with them, before starting any work on the project. For that reason, links to the documentation are a part of the list.
+* [Requirements](#requirements)
+* [Getting started](#getting-started)
+* [Usage](#usage)
+* [JsonApiModel - Handling `links` and `meta` JSON API fields](#jsonapimodel---handling-links-and-meta-json-api-fields)
+* [Retrofit Support](#retrofit-support)
+* [List of libraries used in the project](#list-of-libraries-used-in-the-project)
+* [Contributing](#contributing)
+* [License](#license)
+* [Credits](#credits)
 
-- Kotlinx serialization - [kotlinx.serialization/serialization-guide.md](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/serialization-guide.md)
-- Kotlin poet - https://square.github.io/kotlinpoet/
-
-Along with the libraries documentation, the developer should also know his way around the JSON API, so here is a link to
-the [specification](https://jsonapi.org/).
+## Requirements
 
 ## Getting started
 
@@ -178,7 +183,7 @@ try {
 }
 ```
 
-## Custom error
+### Custom error
 
 Developers can define their own custom error models to adapt to the specific requirements.
 
@@ -308,7 +313,7 @@ person.resourceObjectMeta
 
 ```
 
-## Retrofit
+## Retrofit Support
 
 To enable Retrofit support, you need to add our custom converter in your retrofit builder. It takes an instance of `TypeAdapterFactory` as a
 parameter. No additional steps needed.
@@ -320,21 +325,42 @@ Retrofit.Builder()
     .build()
 ```
 
+## List of libraries used in the project
+
+This chapter lists all the libraries that make a bigger contribution to the project. It is essential for any future
+contributor to get
+familiar with them, before starting any work on the project. For that reason, links to the documentation are a part of
+the list.
+
+- Kotlinx
+  serialization - [kotlinx.serialization/serialization-guide.md](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/serialization-guide.md)
+- Kotlin poet - https://square.github.io/kotlinpoet/
+
+Along with the libraries documentation, the developer should also know his way around the JSON API, so here is a link to
+the [specification](https://jsonapi.org/).
+
 ## Contributing
 
-Feedback and code contributions are very much welcome. Just make a pull request with a short description of your changes. By making
-contributions to this project you give permission for your code to be used under the same [license](LICENSE).
+We believe that the community can help us improve and build better a product.
+Please refer to our [contributing guide](CONTRIBUTING.md) to learn about the types of contributions we accept and the
+process for submitting them.
+
+To ensure that our community remains respectful and professional, we defined
+a [code of conduct](CODE_OF_CONDUCT.md) <!-- and [coding standards](<link>) --> that we expect all contributors to
+follow.
+
+We appreciate your interest and look forward to your contributions.
 
 ## License
 
-```
-Copyright 2021 Infinum
+```text
+Copyright 2024 Infinum
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -345,14 +371,14 @@ limitations under the License.
 
 ## Credits
 
-Maintained and sponsored by [Infinum](http://www.infinum.com).
+Maintained and sponsored by [Infinum](https://infinum.com).
 
-<p align="center">
-  <a href='https://infinum.com'>
+<div align="center">
+    <a href='https://infinum.com'>
     <picture>
         <source srcset="https://assets.infinum.com/brand/logo/static/white.svg" media="(prefers-color-scheme: dark)">
         <img src="https://assets.infinum.com/brand/logo/static/default.svg">
     </picture>
-  </a>
-</p>
+    </a>
+</div>
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@
 
 ## Requirements
 
+The library uses KAPT for annotation processing.
+The setup is different on a Kotlin or Java project.
+
 ## Getting started
 
 Firstly, make sure to include `mavenCentral()` in your buildscript and add the serialization plugin:
@@ -55,13 +58,20 @@ implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.0")
 
 // Json API X
 implementation("com.infinum.jsonapix:core:<latest-version>")
+
+// Kotlin project
 kapt("com.infinum.jsonapix:processor:<latest-version>")
+
+// Java project
+annotationProcessor "com.infinum.jsonapix:processor:<latest-version>"
 
 // Optional: For Retrofit support
 implementation("com.infinum.jsonapix:retrofit:<latest-version>")
 
 // Optional: Custom lint tool checker
 implementation("com.infinum.jsonapix:lint:<latest-version>")
+
+
 ```
 
 ## Usage

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security
+
+## Reporting security issues
+
+At Infinum we are committed to ensuring the security of our software. If you have discovered a security vulnerability or
+have concerns regarding the security of our project, we encourage you to report it to us in a responsible manner.
+
+If you discover a security vulnerability, please report it to us by emailing us at opensource@infinum.com. We will
+review your report, and if the issue is confirmed, we will work to resolve the issue as soon as possible and coordinate
+the release of a security patch.
+
+## Responsible disclosure
+
+We request that you practice responsible disclosure by allowing us time to investigate and address any reported
+vulnerabilities before making them public. We believe this approach helps protect our users and provides a better
+outcome for everyone involved.
+
+## Preferred languages
+
+We prefer all communication to be in English.
+
+## Contributions
+
+We greatly appreciate your help in keeping Infinum projects secure. Your efforts contribute to the ongoing improvement
+of our project's security.


### PR DESCRIPTION
Updated the repo to follow infinum open source template. 

The PR and issue templates and the new MD files (code of conduct, security, ...) are just copied from the infinum template.
Do I have to do anything else to "enable" templates? Or will they be availabe after merging?

Only change is re-ordering in the readme. 

We are also supposed to have the `open-source` tag on the repo (next to the `kotlin`, `android`, ... tags). I dont think I can add this 🤔 